### PR TITLE
fix(deploy): align service and container names for dokploy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  api:
+  resolver:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: stream-resolver-api
+    container_name: stream-resolver
     expose:
       - "${PORT:-8080}"
     environment:
@@ -164,7 +164,7 @@ services:
       - '--web.console.templates=/etc/prometheus/consoles'
       - '--web.enable-lifecycle'
     depends_on:
-      - api
+      - resolver
     networks:
       - resolver-network
     restart: unless-stopped


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration to rename the main service from `api` to `resolver`, ensuring consistent naming throughout the file. The changes also update service dependencies and container naming to reflect this new name.

Service renaming and configuration updates:

* Renamed the service in `docker-compose.yml` from `api` to `resolver`, and updated the corresponding `container_name` to `stream-resolver` for consistency.
* Updated the `depends_on` field for related services to reference `resolver` instead of `api`.